### PR TITLE
This adds support for mixing lastpass credentials with credhub

### DIFF
--- a/lastpass/processor.go
+++ b/lastpass/processor.go
@@ -4,28 +4,34 @@ import (
 	"bytes"
 	"encoding/json"
 	"log"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 
 	"code.cloudfoundry.org/commandrunner"
 	"gopkg.in/yaml.v2"
+	"fmt"
 )
 
 type Processor struct {
 	commandRunner   commandrunner.CommandRunner
-	credentialCache map[string]string
+	credentialCache map[string]cacheResult
+}
+
+type cacheResult struct {
+	 Err error
+	 Result string
 }
 
 func NewProcessor(commandRunner commandrunner.CommandRunner) *Processor {
 	return &Processor{
 		commandRunner:   commandRunner,
-		credentialCache: map[string]string{},
+		credentialCache: map[string]cacheResult{},
 	}
 }
 
 func (l *Processor) Process(config string) string {
+	l.verifyLoggedIn()
 	re := regexp.MustCompile(`\(\((.*)\)\)`)
 
 	processedConfig := re.ReplaceAllStringFunc(config, func(match string) string {
@@ -37,16 +43,25 @@ func (l *Processor) Process(config string) string {
 }
 
 func (l *Processor) handle(credHandle string) string {
-	pathParts := strings.Split(credHandle, "/")
+	var encoded []byte
+	var err error
 
-	credential := l.getCredential(pathParts[0], pathParts[1])
+	pathParts := strings.Split(credHandle, "/")
+	if len(pathParts) == 1 {
+	  encoded, _ = json.Marshal(fmt.Sprintf("((%s))", credHandle))
+	  return string(encoded)
+	}
+
+	err, credential := l.getCredential(pathParts[0], pathParts[1])
+	if err != nil {
+		encoded, _ = json.Marshal(fmt.Sprintf("((%s))", credHandle))
+		return string(encoded)
+	}
 
 	fragment := ""
 	if len(pathParts) > 2 {
 		fragment = pathParts[2]
 	}
-
-	var encoded []byte
 
 	if fragment != "" {
 		// Assume YAML contents, return element
@@ -69,19 +84,21 @@ func (l *Processor) handle(credHandle string) string {
 	return string(encoded)
 }
 
-func (l *Processor) getCredential(credential, field string) string {
+func (l *Processor) getCredential(credential, field string) (error, string) {
+	var err error
 	cacheKey := strings.Join([]string{credential, field}, "/")
-	credentialValue := l.credentialCache[cacheKey]
+	credentialValue := l.credentialCache[cacheKey].Result
+	err = l.credentialCache[cacheKey].Err
 
-	if credentialValue == "" {
-		credentialValue = l.getCredentialFromLastPass(credential, field)
-		l.credentialCache[cacheKey] = credentialValue
+	if credentialValue == "" &&  err == nil {
+		err, credentialValue = l.getCredentialFromLastPass(credential, field)
+		l.credentialCache[cacheKey] = cacheResult{err, credentialValue}
 	}
 
-	return credentialValue
+	return err, credentialValue
 }
 
-func (l *Processor) getCredentialFromLastPass(credential, field string) string {
+func (l *Processor) getCredentialFromLastPass(credential, field string) (error, string) {
 	fieldFlagMap := map[string]string{
 		"Password": "--password",
 		"Username": "--username",
@@ -98,14 +115,26 @@ func (l *Processor) getCredentialFromLastPass(credential, field string) string {
 
 	cmd := exec.Command("lpass", "show", fieldFlag, credential)
 
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
 	cmd.Stdout = output
 
 	err := l.commandRunner.Run(cmd)
 	if err != nil {
-		log.Fatal(err)
+		return err, ""
 	}
 
-	return strings.TrimSpace(output.String())
+	return nil, strings.TrimSpace(output.String())
+}
+
+func (l *Processor) verifyLoggedIn() {
+	cmd := exec.Command("lpass", "status")
+
+	output := &bytes.Buffer{}
+
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err := l.commandRunner.Run(cmd)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("lpass error: %s", output))
+	}
 }

--- a/lastpass/processor.go
+++ b/lastpass/processor.go
@@ -49,13 +49,12 @@ func (l *Processor) handle(credHandle string) string {
 	pathParts := strings.Split(credHandle, "/")
 	if len(pathParts) == 1 {
 	  encoded, _ = json.Marshal(fmt.Sprintf("((%s))", credHandle))
-	  return string(encoded)
+		return fmt.Sprintf("((%s))", credHandle)
 	}
 
 	err, credential := l.getCredential(pathParts[0], pathParts[1])
 	if err != nil {
-		encoded, _ = json.Marshal(fmt.Sprintf("((%s))", credHandle))
-		return string(encoded)
+		return fmt.Sprintf("((%s))", credHandle)
 	}
 
 	fragment := ""

--- a/lastpass/processor_test.go
+++ b/lastpass/processor_test.go
@@ -225,7 +225,7 @@ key-2: "inner-value-2"`))
 		input := "key: ((top_level_field))"
 		output := processor.Process(input)
 
-		Expect(output).To(Equal(`key: "((top_level_field))"`))
+		Expect(output).To(Equal(`key: ((top_level_field))`))
 	})
 
 	It("leaves unknown fields alone", func() {
@@ -243,7 +243,7 @@ key-2: "inner-value-2"`))
 		input := "key: ((unknown/secret))"
 		output := processor.Process(input)
 
-		Expect(output).To(Equal(`key: "((unknown/secret))"`))
+		Expect(output).To(Equal(`key: ((unknown/secret))`))
 	})
 
 	It("caches lpass error values", func() {
@@ -262,8 +262,8 @@ key-2: "inner-value-2"`))
 key-2: ((unknown/secret))`
 		output := processor.Process(input)
 
-		Expect(output).To(Equal(`key-1: "((unknown/secret))"
-key-2: "((unknown/secret))"`))
+		Expect(output).To(Equal(`key-1: ((unknown/secret))
+key-2: ((unknown/secret))`))
 
 		Expect(commandRunner.ExecutedCommands()).To(HaveLen(2))
 	})


### PR DESCRIPTION
If a `((cred_path))` is not found in lastpass, it will simply be left alone.